### PR TITLE
Fixes bug where Material themed dialog´s with active buttons always fills the complete window width even on tablets

### DIFF
--- a/alertdialogpro-demo/src/main/java/com/alertdialogpro/demo/MainActivity.java
+++ b/alertdialogpro-demo/src/main/java/com/alertdialogpro/demo/MainActivity.java
@@ -4,7 +4,7 @@ import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.RadioGroup;
 import android.widget.Toast;
@@ -15,7 +15,7 @@ import com.alertdialogpro.ProgressDialogPro;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MainActivity extends ActionBarActivity implements View.OnClickListener {
+public class MainActivity extends AppCompatActivity implements View.OnClickListener {
     private static final int NATIVE_THEME = Integer.MIN_VALUE;
     private int mTheme = -1;
 
@@ -52,6 +52,7 @@ public class MainActivity extends ActionBarActivity implements View.OnClickListe
         });
 
         findViewById(R.id.showMessage).setOnClickListener(this);
+        findViewById(R.id.showLongMessage).setOnClickListener(this);
         findViewById(R.id.showProgress).setOnClickListener(this);
         findViewById(R.id.showProgressHorizontal).setOnClickListener(this);
         findViewById(R.id.showList).setOnClickListener(this);
@@ -65,6 +66,9 @@ public class MainActivity extends ActionBarActivity implements View.OnClickListe
         switch (v.getId()) {
             case R.id.showMessage:
                 showMessageAlertDialog();
+                break;
+            case R.id.showLongMessage:
+                showLongMessageAlertDialog();
                 break;
             case R.id.showProgress:
                 showProgressDialog();
@@ -107,6 +111,14 @@ public class MainActivity extends ActionBarActivity implements View.OnClickListe
         createAlertDialogBuilder()
                 .setTitle(R.string.app_name)
                 .setMessage("Hello, charming AlertDialogPro!")
+                .setPositiveButton("Nice Job", new ButtonClickedListener("Dismiss"))
+                .show();
+    }
+
+    private void showLongMessageAlertDialog(){
+        createAlertDialogBuilder()
+                .setTitle(R.string.app_name)
+                .setMessage("Hello, charming AlertDialogPro! This message is a bit longer than you would expect, so you can see how nicely this dialog behaves on tablets and landscape orientations. The Dialog does not stretch to fill the width but maintains a nice aspect ratio, yeaaa!")
                 .setPositiveButton("Nice Job", new ButtonClickedListener("Dismiss"))
                 .show();
     }

--- a/alertdialogpro-demo/src/main/res/layout/activity_my.xml
+++ b/alertdialogpro-demo/src/main/res/layout/activity_my.xml
@@ -70,10 +70,18 @@
             android:text="Show Message" />
 
         <Button
-            android:id="@+id/showProgress"
+            android:id="@+id/showLongMessage"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_below="@id/showMessage"
+            android:layout_marginTop="12dp"
+            android:text="Show Long Message" />
+
+        <Button
+            android:id="@+id/showProgress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/showLongMessage"
             android:layout_marginTop="12dp"
             android:text="Show Progress" />
 

--- a/alertdialogpro-theme-material/src/main/res/layout/adp_alert_dialog_material.xml
+++ b/alertdialogpro-theme-material/src/main/res/layout/adp_alert_dialog_material.xml
@@ -111,11 +111,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 
-        <View
+        <android.support.v4.widget.Space
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:visibility="invisible" />
+            android:visibility="invisible"/>
 
         <com.alertdialogpro.material.ButtonCompat
             android:id="@id/adp_button2"


### PR DESCRIPTION
@Material
Fixes an annoying bug where Material themed dialog´s with active buttons always fill the complete window width even on tablets On phones this isn't very visible but on tablets this bug shows ugly long stretched dialog´s.

@Demo
Added 'long message' type dialog to the demo app (to demonstrated the bug fix) and updated some deprecated AppCompat API's.