### PR TITLE
Theme clean-up and better API 8, 9  and 10 support

### DIFF
--- a/alertdialogpro-core/src/main/java/com/alertdialogpro/internal/AlertController.java
+++ b/alertdialogpro-core/src/main/java/com/alertdialogpro/internal/AlertController.java
@@ -218,17 +218,6 @@ public class AlertController {
     }
 
     private void applyFixedSizeWindow(ContentFrameLayout contentFrameLayout) {
-        /*
-        // This is a bit weird. In the framework, the window sizing attributes control
-        // the decor view's size, meaning that any padding is inset for the min/max widths below.
-        // We don't control measurement at that level, so we need to workaround it by making sure
-        // that the decor view's padding is taken into account.
-
-        contentFrameLayout.setDecorPadding(mWindowDecor.getPaddingLeft(),
-                mWindowDecor.getPaddingTop(), mWindowDecor.getPaddingRight(),
-                mWindowDecor.getPaddingBottom());
-        */
-
         TypedArray a = contentFrameLayout.getContext().obtainStyledAttributes(R.styleable.Theme);
         a.getValue(R.styleable.Theme_windowMinWidthMajor, contentFrameLayout.getMinWidthMajor());
         a.getValue(R.styleable.Theme_windowMinWidthMinor, contentFrameLayout.getMinWidthMinor());

--- a/alertdialogpro-core/src/main/res/layout/adp_alert_dialog_base.xml
+++ b/alertdialogpro-core/src/main/res/layout/adp_alert_dialog_base.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.internal.widget.ContentFrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:foreground="?android:attr/windowContentOverlay"
+    android:foregroundGravity="fill_horizontal|top"/>

--- a/alertdialogpro-core/src/main/res/values-large/adp_core_dimens.xml
+++ b/alertdialogpro-core/src/main/res/values-large/adp_core_dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="dimen" name="adp_dialog_min_width_major">55%</item>
+    <item type="dimen" name="adp_dialog_min_width_minor">80%</item>
+</resources>

--- a/alertdialogpro-core/src/main/res/values-v11/adp_core_themes.xml
+++ b/alertdialogpro-core/src/main/res/values-v11/adp_core_themes.xml
@@ -1,13 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
 
     <style name="Base.Theme.AlertDialogPro" parent="Theme.AppCompat.Dialog">
-        <item name="android:windowMinWidthMajor">@android:dimen/dialog_min_width_major</item>
-        <item name="android:windowMinWidthMinor">@android:dimen/dialog_min_width_minor</item>
+        <!-- Use native windowMinWidth attributes on API 11 and higher -->
+        <item name="android:windowMinWidthMajor">@dimen/adp_dialog_min_width_major</item>
+        <item name="android:windowMinWidthMinor">@dimen/adp_dialog_min_width_minor</item>
     </style>
 
     <style name="Base.Theme.AlertDialogPro.Light" parent="Theme.AppCompat.Light.Dialog">
-        <item name="android:windowMinWidthMajor">@android:dimen/dialog_min_width_major</item>
-        <item name="android:windowMinWidthMinor">@android:dimen/dialog_min_width_minor</item>
+        <!-- Use native windowMinWidth attributes on API 11 and higher -->
+        <item name="android:windowMinWidthMajor">@dimen/adp_dialog_min_width_major</item>
+        <item name="android:windowMinWidthMinor">@dimen/adp_dialog_min_width_minor</item>
     </style>
 
 </resources>

--- a/alertdialogpro-core/src/main/res/values-xlarge/adp_core_dimens.xml
+++ b/alertdialogpro-core/src/main/res/values-xlarge/adp_core_dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="dimen" name="adp_dialog_min_width_major">45%</item>
+    <item type="dimen" name="adp_dialog_min_width_minor">72%</item>
+</resources>

--- a/alertdialogpro-core/src/main/res/values/adp_core_dimens.xml
+++ b/alertdialogpro-core/src/main/res/values/adp_core_dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="dimen" name="adp_dialog_min_width_major">65%</item>
+    <item type="dimen" name="adp_dialog_min_width_minor">95%</item>
+</resources>

--- a/alertdialogpro-core/src/main/res/values/adp_core_themes.xml
+++ b/alertdialogpro-core/src/main/res/values/adp_core_themes.xml
@@ -1,49 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Base.Theme.AlertDialogPro" parent="Theme.AppCompat.Dialog"/>
+    <style name="Base.Theme.AlertDialogPro" parent="Theme.AppCompat.Dialog">
+        <item name="windowMinWidthMajor">@dimen/adp_dialog_min_width_major</item>
+        <item name="windowMinWidthMinor">@dimen/adp_dialog_min_width_minor</item>
+    </style>
 
     <style name="Base.Theme.AlertDialogPro.Light" parent="Theme.AppCompat.Light.Dialog">
-        <item name="android:windowNoTitle">true</item>
-        <item name="buttonBarStyle">@android:style/ButtonBar</item>
-        <item name="buttonBarButtonStyle">@android:style/Widget.Button</item>
-
-        <!-- Window colors -->
-        <item name="android:colorForeground">@color/bright_foreground_material_light</item>
-        <item name="android:colorForegroundInverse">@color/bright_foreground_material_dark</item>
-        <item name="android:colorBackground">@color/background_material_light</item>
-        <item name="android:colorBackgroundCacheHint">@color/abc_background_cache_hint_selector_material_light</item>
-        <item name="android:disabledAlpha">0.5</item>
-        <item name="android:backgroundDimAmount">0.6</item>
-        <item name="android:windowBackground">@color/background_material_light</item>
-
-        <!-- Text colors -->
-        <item name="android:textColorPrimary">@color/abc_primary_text_material_light</item>
-        <item name="android:textColorPrimaryInverse">@color/abc_primary_text_material_dark</item>
-        <item name="android:textColorSecondary">@color/abc_secondary_text_material_light</item>
-        <item name="android:textColorSecondaryInverse">@color/abc_secondary_text_material_dark</item>
-        <item name="android:textColorTertiary">@color/abc_secondary_text_material_light</item>
-        <item name="android:textColorTertiaryInverse">@color/abc_secondary_text_material_dark</item>
-        <item name="android:textColorPrimaryDisableOnly">@color/abc_primary_text_disable_only_material_light</item>
-        <item name="android:textColorPrimaryInverseDisableOnly">@color/abc_primary_text_disable_only_material_dark</item>
-        <item name="android:textColorHint">@color/hint_foreground_material_light</item>
-        <item name="android:textColorHintInverse">@color/hint_foreground_material_dark</item>
-        <item name="android:textColorHighlight">@color/highlighted_text_material_light</item>
-        <item name="android:textColorLink">@color/link_text_material_light</item>
-
-        <!-- Text styles -->
-        <item name="android:textAppearance">@style/TextAppearance.AppCompat</item>
-        <item name="android:textAppearanceInverse">@style/TextAppearance.AppCompat.Inverse</item>
-        <item name="android:textAppearanceLarge">@style/TextAppearance.AppCompat.Large</item>
-        <item name="android:textAppearanceLargeInverse">@style/TextAppearance.AppCompat.Large.Inverse</item>
-        <item name="android:textAppearanceMedium">@style/TextAppearance.AppCompat.Medium</item>
-        <item name="android:textAppearanceMediumInverse">@style/TextAppearance.AppCompat.Medium.Inverse</item>
-        <item name="android:textAppearanceSmall">@style/TextAppearance.AppCompat.Small</item>
-        <item name="android:textAppearanceSmallInverse">@style/TextAppearance.AppCompat.Small.Inverse</item>
-        <item name="android:spinnerStyle">@style/Widget.AppCompat.Spinner</item>
-        <item name="android:dropDownListViewStyle">@style/Widget.AppCompat.ListView.DropDown</item>
-        <item name="android:listChoiceIndicatorSingle">@drawable/abc_btn_radio_material</item>
-        <item name="android:listChoiceIndicatorMultiple">@drawable/abc_btn_check_material</item>
+        <item name="windowMinWidthMajor">@dimen/adp_dialog_min_width_major</item>
+        <item name="windowMinWidthMinor">@dimen/adp_dialog_min_width_minor</item>
     </style>
 
     <style name="Theme.AlertDialogPro" parent="Base.Theme.AlertDialogPro">


### PR DESCRIPTION
I cleaned the AlertDialogPro themes and back-ported the windowMinWidthMajor and windowMinWidthMinor attributes for API 8, 9 and 10 just like AppCompat version 22.1.X does. The only difference is that the android:windowMinWidthMajor and android:windowMinWidthMinor should still be used for API 11 and above, this is not the case in the AppCompat AlertDialog implementation, in AppCompat the windowMinWidthMajor and windowMinWidthMinor attributes do work for API 11 and above.

I also added the default values (default, large and xlarge) for windowMinWidthMajor and windowMinWidthMinor because they can vary across different Android versions, custom roms and sometimes even manufactures.

Tested on multiple devices, emulators and Android versions. Also my app Tinycore will receive an update today with these changes implemented, so that will be the big test ;)