### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,25 @@
-#Change Log
-####v0.2.6
+# Change Log
+#### v0.2.6
 * Upgrade to AppCompat 23.1.1
 
-####v0.2.5
+#### v0.2.5
 * Upgrade to AppCompat 23.1.0
 
-####v0.2.4
+#### v0.2.4
 * Upgrade to AppCompat 23.0.0
 
-####v0.2.3
+#### v0.2.3
 * Add support for AppCompat 22.1.0
 
-####v0.2.2
+#### v0.2.2
 * Fix issue [#45](https://github.com/fengdai/AlertDialogPro/issues/45)
 
-####v0.2.1
+#### v0.2.1
 * Workaround for issue [#17](https://github.com/fengdai/AlertDialogPro/issues/17)
 
-####v0.2.0
+#### v0.2.0
 * Add ProgressDialogPro
 * Fix bug of CheckedTextedView [#30](https://github.com/fengdai/AlertDialogPro/issues/30)
 
-####v0.1.0
+#### v0.1.0
 * Initial version


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
